### PR TITLE
Add interactive progress bar with click, drag, and message ticks

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,18 +108,63 @@
 
   #progress-bar {
     flex: 1;
-    height: 3px;
+    height: 12px;
     background: var(--border);
-    border-radius: 2px;
+    border-radius: 3px;
     cursor: pointer;
+    position: relative;
+    display: flex;
+    align-items: stretch;
   }
 
   #progress-fill {
     height: 100%;
     background: var(--blue);
-    border-radius: 2px;
+    border-radius: 3px;
     width: 0%;
     transition: width 0.1s;
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+  }
+
+  #progress-ticks {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    pointer-events: none;
+  }
+
+  .progress-tick {
+    flex: 1;
+    border-right: 1px solid rgba(255,255,255,0.08);
+    position: relative;
+  }
+
+  .progress-tick:last-child { border-right: none; }
+
+  .progress-tick.tick-user {
+    background: rgba(86, 156, 214, 0.15);
+  }
+
+  .progress-tick.tick-assistant {
+    background: transparent;
+  }
+
+  #progress-bar:hover .progress-tick {
+    border-right-color: rgba(255,255,255,0.15);
+  }
+
+  #progress-bar.dragging {
+    cursor: grabbing;
+  }
+
+  #progress-bar.dragging #progress-fill {
+    transition: none;
   }
 
   .ctrl-sep { width: 1px; height: 20px; background: var(--border); }
@@ -493,7 +538,7 @@
     <div class="ctrl-sep"></div>
     <button class="ctrl-btn" id="btn-realtime" title="Real-time mode (T) — use actual timestamps">Real-time</button>
     <div class="ctrl-sep"></div>
-    <div id="progress-bar"><div id="progress-fill"></div></div>
+    <div id="progress-bar"><div id="progress-fill"></div><div id="progress-ticks"></div></div>
     <div id="msg-counter"></div>
     <div class="ctrl-sep"></div>
     <button id="new-file-btn">New file</button>
@@ -803,7 +848,9 @@ function renderTaskList() {
 // --- Playback ---
 const chat = document.getElementById('chat');
 const chatInner = document.getElementById('chat-inner');
+const progressBar = document.getElementById('progress-bar');
 const progressFill = document.getElementById('progress-fill');
+const progressTicks = document.getElementById('progress-ticks');
 const msgCounter = document.getElementById('msg-counter');
 const statusDot = document.getElementById('status-dot');
 const statusTextEl = document.getElementById('status-text');
@@ -818,6 +865,158 @@ function updateStatus(state, text) {
   statusDot.className = 'status-dot ' + state;
   statusTextEl.textContent = text;
 }
+
+// --- Progress bar ticks ---
+function buildProgressTicks() {
+  progressTicks.innerHTML = '';
+  for (let i = 0; i < messages.length; i++) {
+    const tick = document.createElement('div');
+    tick.className = 'progress-tick ' + (messages[i].type === 'user' ? 'tick-user' : 'tick-assistant');
+    progressTicks.appendChild(tick);
+  }
+}
+
+// --- Instant rendering (for seeking) ---
+function renderUserInstant(msg) {
+  const el = document.createElement('div');
+  el.className = 'msg-user';
+  const prompt = document.createElement('span');
+  prompt.className = 'user-prompt';
+  prompt.textContent = '❯';
+  const textSpan = document.createElement('span');
+  textSpan.className = 'user-text';
+  textSpan.textContent = msg.text;
+  el.appendChild(prompt);
+  el.appendChild(textSpan);
+  chatInner.appendChild(el);
+}
+
+function renderAssistantInstant(msg) {
+  const startTime = Date.now();
+  for (const block of msg.content) {
+    if (block.type === 'text' && block.text) {
+      const el = document.createElement('div');
+      el.className = 'assistant-block bullet-text';
+      el.innerHTML = '<span class="bullet">●</span>' + md(block.text);
+      chatInner.appendChild(el);
+    } else if (block.type === 'tool_use') {
+      if (isTaskTool(block.name)) {
+        handleTaskTool(block);
+        continue;
+      }
+      // Tool call
+      const summary = getToolSummary(block);
+      const command = getToolCommand(block);
+      const commandLines = command.split('\n');
+      const previewLine = commandLines[0].substring(0, 90);
+      const extraLines = commandLines.length - 1;
+      const toolEl = document.createElement('div');
+      toolEl.className = 'tool-call';
+      toolEl.innerHTML = `
+        <div class="tool-call-header" onclick="this.parentElement.classList.toggle('open')">
+          <span class="bullet">●</span>
+          <span class="tool-call-name">${escHtml(block.name)}</span><span class="tool-call-paren">(</span><span class="tool-call-summary">${escHtml(summary)}</span><span class="tool-call-paren">)</span>
+        </div>
+        <div class="tool-call-body"><pre>${escHtml(redact(previewLine))}</pre></div>
+        ${extraLines > 0 ? `<div class="tool-call-expand" onclick="this.parentElement.classList.toggle('open')">… +${extraLines} lines (click to expand)</div>` : ''}
+      `;
+      chatInner.appendChild(toolEl);
+      // Tool result
+      if (block.result) {
+        const r = block.result;
+        const isError = r.is_error;
+        const resultText = r.stdout || r.content || '';
+        const stderrText = r.stderr || '';
+        const displayText = (resultText + (stderrText ? '\n' + stderrText : '')).trim();
+        if (displayText) {
+          const redacted = redact(displayText);
+          const resultLines = redacted.split('\n');
+          const previewText = resultLines[0].substring(0, 90);
+          const moreLines = resultLines.length - 1;
+          const resultEl = document.createElement('div');
+          resultEl.className = `tool-result ${isError ? 'error' : ''}`;
+          resultEl.innerHTML = `
+            <div class="tool-result-line" onclick="this.parentElement.classList.toggle('open')">
+              <span class="tool-result-connector">└</span>
+              <span class="tool-result-preview">${escHtml(previewText)}</span>
+            </div>
+            ${moreLines > 0 ? `<div class="tool-result-expand" onclick="this.parentElement.classList.toggle('open')">… +${moreLines} lines (click to expand)</div>` : ''}
+            <div class="tool-result-body"><pre>${escHtml(redacted)}</pre></div>
+          `;
+          chatInner.appendChild(resultEl);
+        }
+      }
+    }
+  }
+  // Status line
+  const statusEl = document.createElement('div');
+  statusEl.className = 'status-line';
+  statusEl.innerHTML = `<span class="status-icon">✱</span> Worked for 0s`;
+  chatInner.appendChild(statusEl);
+}
+
+function renderMessageInstant(msg) {
+  if (msg.type === 'user') renderUserInstant(msg);
+  else if (msg.type === 'assistant') renderAssistantInstant(msg);
+}
+
+function seekTo(targetIndex) {
+  targetIndex = Math.max(0, Math.min(targetIndex, messages.length));
+
+  // Stop playback
+  playing = false;
+  updatePlayButton();
+
+  if (targetIndex <= currentIndex) {
+    // Backward seek — must rebuild from scratch
+    chatInner.innerHTML = '';
+    taskState.clear();
+    taskCounter = 0;
+    taskPanel.innerHTML = '';
+    taskPanel.classList.remove('visible');
+    for (let i = 0; i < targetIndex; i++) {
+      renderMessageInstant(messages[i]);
+    }
+  } else {
+    // Forward seek — render from current to target
+    for (let i = currentIndex; i < targetIndex; i++) {
+      renderMessageInstant(messages[i]);
+    }
+  }
+
+  currentIndex = targetIndex;
+  updateProgress();
+  updateStatus('paused', 'Paused');
+  chat.scrollTop = chat.scrollHeight;
+}
+
+// --- Progress bar interaction ---
+function getProgressIndex(e) {
+  const rect = progressBar.getBoundingClientRect();
+  const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+  return Math.round(pct * messages.length);
+}
+
+let dragging = false;
+
+progressBar.addEventListener('mousedown', (e) => {
+  if (messages.length === 0) return;
+  dragging = true;
+  progressBar.classList.add('dragging');
+  seekTo(getProgressIndex(e));
+  e.preventDefault();
+});
+
+document.addEventListener('mousemove', (e) => {
+  if (!dragging) return;
+  seekTo(getProgressIndex(e));
+});
+
+document.addEventListener('mouseup', (e) => {
+  if (!dragging) return;
+  dragging = false;
+  progressBar.classList.remove('dragging');
+});
 
 async function showMessage(index) {
   if (index >= messages.length) {
@@ -1048,6 +1247,7 @@ document.getElementById('new-file-btn').onclick = () => {
   taskCounter = 0;
   taskPanel.innerHTML = '';
   taskPanel.classList.remove('visible');
+  progressTicks.innerHTML = '';
   updatePlayButton();
 };
 
@@ -1080,6 +1280,7 @@ function loadFile(file) {
       info.gitBranch ? info.gitBranch : '';
 
     updateProgress();
+    buildProgressTicks();
     updateStatus('idle', `${messages.length} messages loaded`);
   };
   reader.readAsText(file);


### PR DESCRIPTION
## Summary
- Progress bar is now clickable and draggable for seeking through conversations
- Tick marks at each message boundary visually distinguish user (blue tint) vs assistant messages
- Live scrubbing updates the view as you drag, not just on release
- Backward seeking correctly clears DOM and rebuilds task state from scratch

## Changes
- Increased progress bar height (3px → 12px) for easier interaction
- Added `seekTo()` with forward (append) and backward (clear + rebuild) logic
- Added instant rendering helpers (`renderUserInstant`, `renderAssistantInstant`, `renderMessageInstant`)
- Added mousedown/mousemove/mouseup drag handlers with live scrubbing
- Added `buildProgressTicks()` to create per-message tick marks on file load
- Progress counter updates after seek

Closes #6