### PR TITLE
Fix auto-scroll preventing manual scrolling during playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -879,6 +879,17 @@ function autoScroll() {
   chat.scrollTop = chat.scrollHeight;
   scrollingProgrammatically = false;
 }
+
+// ResizeObserver: catches cases where scrollHeight updates after layout
+// reflow (e.g. images loading, markdown rendering) that the synchronous
+// autoScroll() call misses because scrollHeight was stale.
+const resizeObserver = new ResizeObserver(() => {
+  if (!autoScrollEnabled) return;
+  scrollingProgrammatically = true;
+  chat.scrollTop = chat.scrollHeight;
+  scrollingProgrammatically = false;
+});
+resizeObserver.observe(chatInner);
 const progressBar = document.getElementById('progress-bar');
 const progressFill = document.getElementById('progress-fill');
 const progressTicks = document.getElementById('progress-ticks');


### PR DESCRIPTION
## Summary
- Add `isNearBottom()` check (50px threshold) and `autoScroll()` wrapper function
- Replace all unconditional `chat.scrollTop = chat.scrollHeight` calls during playback with `autoScroll()`
- Auto-scroll pauses when user scrolls up, resumes when they scroll back to bottom
- `seekTo()` still forces scroll since it's an explicit user action
- Fix progress bar jumping back on click: `seekTo()` now cancels active animations via `playGeneration++` so the running `showMessage` can't overwrite `currentIndex` after a seek

Closes #5

## Test plan
- [ ] Load a long conversation and start playback
- [ ] While playing, scroll up manually — verify playback continues without pulling you back down
- [ ] Scroll back to bottom — verify auto-scroll resumes
- [ ] Use Step button while scrolled up — verify it doesn't force-scroll
- [ ] Use progress bar seeking — verify it does scroll to bottom (explicit action)
- [ ] Click progress bar mid-playback — verify it seeks to correct position without jumping back

🤖 Generated with [Claude Code](https://claude.com/claude-code)